### PR TITLE
fix: github 로그인 시 redirect url 같이 넘겨주도록

### DIFF
--- a/src/components/SignInBtn.jsx
+++ b/src/components/SignInBtn.jsx
@@ -1,11 +1,13 @@
 //src>components>SignInBtn.jsx
 
+import { APP_BASE_URL } from '../settting';
 import { supabase } from '../supabaseClient';
 
 function SignInBtn() {
   const signInWithGithub = async () => {
     await supabase.auth.signInWithOAuth({
       provider: 'github',
+      redirectTo: APP_BASE_URL,
     });
   };
 

--- a/src/settting.js
+++ b/src/settting.js
@@ -1,0 +1,1 @@
+export const APP_BASE_URL = import.meta.env.APP_BASE_URL;


### PR DESCRIPTION
vercel 배포분에서 github 로그인 시 redirect url 이 default 값인 localhost 로 되어 있어, 잘못된 페이지로 이동되는 문제가 있습니다. 이를 해결하기 위해 .env.local 에 환경변수를 추가했습니다.

아래 내용을 넣어야만 로컬에서 깃헙로그인을 할 수 있어요
```APP_BASE_URL = 'http://localhost:5173/';```